### PR TITLE
added common fields to info hash

### DIFF
--- a/lib/omniauth/strategies/xing.rb
+++ b/lib/omniauth/strategies/xing.rb
@@ -20,9 +20,9 @@ module OmniAuth
           :email        => raw_info["active_email"],
           :image        => raw_info["photo_urls"]["large"],
           :url          => raw_info["permalink"],
-          :name         => raw_info["first_name"] + " " + raw_info["last_name"],
+          :name         => raw_info["display_name"],
           :urls         => {
-            'Website' => raw_info["permalink"]
+            'public_profile' => raw_info["permalink"]
           }
         }
       end


### PR DESCRIPTION
added two very common fields to the info-hash:
- _name_ (simply concating first_name and last_name) 
- _urls_ hash (adding the permalink with key "Website").
  These fields are widely used by many other omniauth strategies (see my extensive research ;-) ), having those in the XING strategy just makes it a few seconds easier to use. Nothing much to write home about, but if you're in the mood to merge something small, this might suite your desires. 

![typical-info-fields-omniauth](https://f.cloud.github.com/assets/419801/614097/168e6344-ce15-11e2-845c-0bfbb95b9402.png)
